### PR TITLE
Bumping the version number?

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "p.bergsmann@opendo.at"
 license          "All rights reserved"
 description      "Installs/Configures locales"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.1.0"
+version          "0.1.1"
 
 supports "ubuntu"
 supports "debian"


### PR DESCRIPTION
Can we just bump the version number in the metadata.rb file too? The version stored in opsocde thinks it is still version 0.1.0 because of this.
