### PR TITLE
Fix for Ubuntu 12

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -8,7 +8,12 @@ action :add do
     unless locale_available?(locale)
       case node['platform_family']
         when "debian"
-          file_append_line('/etc/locale.gen', "#{high_locale(locale)} UTF-8")
+          if platform?("ubuntu")
+            locale_path = "/var/lib/locales/supported.d/local"
+          else
+            locale_path = "/etc/locale.gen"
+          end
+          file_append_line(locale_path, "#{high_locale(locale)} UTF-8")
           execute "dpkg-reconfigure" do
             command "dpkg-reconfigure --frontend=noninteractive locales"
             action :run


### PR DESCRIPTION
I had troubles executing this cookbook on Ubuntu 12. According to pull request https://github.com/danhart/locale-gen/pull/3 of the project locale-gen, from Ubuntu 12 onwards locales are stored in  `/var/lib/locales/supported.d/local` instead of `/etc/locale.gen`. I made similar changes to this codebase and got it working properly on Ubuntu.
