### PR TITLE
Be sure that `node['locales']['locale_file']` exists

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -1,3 +1,8 @@
 execute 'locale-gen' do
   action :nothing
 end
+
+file node['locales']['locale_file'] do
+  owner 'root'
+  group 'root'
+end


### PR DESCRIPTION
After testing with docker (on very limited ubuntu dist), `Chef::Util::FileEdit` fail if file doesn't exist.
