### PR TITLE
Rename helper module to avoid issues on Chef 12:

### DIFF
--- a/libraries/localeshelper.rb
+++ b/libraries/localeshelper.rb
@@ -1,4 +1,4 @@
-module Locales
+module ChefLocales
   module Helper
     def current_locale
       cmd = Mixlib::ShellOut.new('locale').run_command

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -1,4 +1,4 @@
-include ::Locales::Helper
+include ::ChefLocales::Helper
 
 # Support whyrun
 def whyrun_supported?


### PR DESCRIPTION
There's some kind of name resolution conflict with the way Chef 12 looks up the provider for a lightweight Resource, and it tries to call the helper module as if it were the Provider class. This avoids the clash

This solves #27 
